### PR TITLE
Improved control plugin

### DIFF
--- a/ros/config/robots/franka_config.yaml
+++ b/ros/config/robots/franka_config.yaml
@@ -11,7 +11,7 @@ plugins:
   - module: pybullet_ros.plugins.joint_state_pub
     class: joinStatePub
 
-loop_rate: 1000.0            # default: 80.0, the frequency at which to step sim in hz
+loop_rate: 500.0            # default: 80.0, the frequency at which to step sim in hz
 gravity: -9.81           # default: -9.81, earth gravity in m/s^2
 max_effort: 100.0           # default: 50.0, the max force to apply to the model in vel mode
 

--- a/ros/launch/robots/franka.launch
+++ b/ros/launch/robots/franka.launch
@@ -4,7 +4,7 @@
     <!-- Parameterized sample launch file to bringup a robot with pybullet ros wrapper in a ROS ecosystem
          It launches by default a sample R2D2 robot -->
 
-    <arg name="config_file" default="franka_config.yaml"/>
+    <arg name="config_file" default="$(find pybullet_ros)/ros/config/robots/franka_config.yaml"/>
     <!-- e.g. from my_ros_pkg.my_env import Environment ; "my_env" is what you set in environment param below-->
     <arg name="plugin_import_prefix" default="pybullet_ros.plugins"/>
     <arg name="environment" default="environment"/> <!-- name of python file without the .py inside plugins folder -->

--- a/ros/scripts/joint_states_to_float
+++ b/ros/scripts/joint_states_to_float
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import rospy
-from std_msgs.msg import Float64
+from std_msgs.msg import Float64MultiArray
 from sensor_msgs.msg import JointState
+
 
 class JointStatesToFloat:
     def __init__(self):
@@ -15,12 +16,9 @@ class JointStatesToFloat:
         self.wait_for_first_msg()
         rospy.loginfo('joint state msg received, proceeding')
         # init previous angle list
-        for i in range(len(self.joint_state_msg.position)):
-            self.previous_angles.append(0.0)
-        # create one publisher per joint name
-        self.pub_list = []
-        for name in self.joint_state_msg.name:
-            self.pub_list.append(rospy.Publisher(name + '_position_controller/command', Float64, queue_size=1))
+        self.previous_angles = [0] * len(self.joint_state_msg.position)
+        # create one publisher
+        self.pub = rospy.Publisher('/position_controller/command', Float64MultiArray, queue_size=1)
 
     def wait_for_first_msg(self):
         while not self.msg_received:
@@ -33,19 +31,16 @@ class JointStatesToFloat:
 
     def publishJointsAsFloats(self):
         # extract desired angles from joint state msg
-        angles = []
-        for angle in self.joint_state_msg.position:
-            angles.append(angle)
+        angles = [a for a in self.joint_state_msg.position]
         # compare previous angles to see if there was any change
         changes = []
         for i, previous_angle in enumerate(self.previous_angles):
             changes.append(previous_angle != angles[i])
-        # publish desired angles to float topics
-        for i, pub in enumerate(self.pub_list):
-            if changes[i]: # compute only if angle changed
-                float_msg = Float64()
-                float_msg.data = angles[i]
-                pub.publish(float_msg)
+        # publish desired angles to float topic
+        if any(changes):
+            float_msg = Float64MultiArray()
+            float_msg.data = angles
+            self.pub.publish(float_msg)
         # to keep track if the angle changed or not
         self.previous_angles = angles
 
@@ -56,6 +51,7 @@ class JointStatesToFloat:
                 self.msg_received = False
                 self.publishJointsAsFloats()
             self.rate.sleep()
+
 
 if __name__ == '__main__':
     rospy.init_node('joint_states_to_float', anonymous=False)

--- a/ros/src/pybullet_ros/plugins/control.py
+++ b/ros/src/pybullet_ros/plugins/control.py
@@ -5,26 +5,27 @@ position, velocity and effort control for all revolute joints on the robot
 """
 
 import rospy
-from std_msgs.msg import Float64
+from std_msgs.msg import Float64MultiArray
+
 
 # NOTE: 2 classes are implemented here, scroll down to the next class (Control) to see the plugin!
 
+
 class pveControl:
     """helper class to receive position, velocity or effort (pve) control commands"""
-    def __init__(self, joint_index, joint_name, controller_type):
+
+    def __init__(self, controller_type):
         """constructor
         Assumes joint_name is unique, creates multiple subscribers to receive commands
         joint_index - stores an integer joint identifier
         joint_name - string with the name of the joint as described in urdf model
         controller_type - position, velocity or effort
         """
-        assert(controller_type in ['position', 'velocity', 'effort'])
-        rospy.Subscriber(joint_name + '_' + controller_type + '_controller/command',
-                         Float64, self.pve_controlCB, queue_size=1)
+        assert (controller_type in ['position', 'velocity', 'effort'])
+        rospy.Subscriber("/" + controller_type + '_controller/command',
+                         Float64MultiArray, self.pve_controlCB, queue_size=1)
         self.cmd = 0.0
         self.data_available = False
-        self.joint_index = joint_index
-        self.joint_name = joint_name
 
     def pve_controlCB(self, msg):
         """position, velocity or effort callback
@@ -42,13 +43,6 @@ class pveControl:
         """method to retrieve flag to indicate that a command has been received"""
         return self.data_available
 
-    def get_joint_name(self):
-        """Unused method provided for completeness (pybullet works based upon joint index, not names)"""
-        return self.joint_name
-
-    def get_joint_index(self):
-        """method used to retrieve the joint int index that this class points to"""
-        return self.joint_index
 
 # plugin is implemented below
 class Control:
@@ -57,10 +51,13 @@ class Control:
         self.pb = pybullet
         # get robot from parent class
         self.robot = robot
+        # get joints names and store them in dictionary, combine both revolute and prismatic dic
+        joint_index_name_dic = {**kargs['rev_joints'], **kargs['prism_joints']}
+        self.joint_indices = [joint for joint in joint_index_name_dic]
         # lists to recall last received command (useful when controlling multiple joints)
-        self.position_joint_commands = []
-        self.velocity_joint_commands = []
-        self.effort_joint_commands = []
+        self.position_joint_commands = [0] * len(self.joint_indices)
+        self.velocity_joint_commands = [0] * len(self.joint_indices)
+        self.effort_joint_commands = [0] * len(self.joint_indices)
         # this parameter will be set for all robot joints
         if rospy.has_param('~max_effort_vel_mode'):
             rospy.logwarn('max_effort_vel_mode parameter is deprecated, please use max_effort instead')
@@ -69,31 +66,11 @@ class Control:
         else:
             max_effort = rospy.get_param('~max_effort', 100.0)
         # the max force to apply to the joint, used in velocity control
-        self.force_commands = []
-        # get joints names and store them in dictionary, combine both revolute and prismatic dic
-        self.joint_index_name_dic = {**kargs['rev_joints'], **kargs['prism_joints']}
+        self.force_commands = [max_effort] * len(self.joint_indices)
         # setup subscribers
-        self.pc_subscribers = []
-        self.vc_subscribers = []
-        self.ec_subscribers = []
-        self.joint_indices = []
-        # revolute joints - joint position, velocity and effort control command individual subscribers
-        for joint_index in self.joint_index_name_dic:
-            self.position_joint_commands.append(0.0)
-            self.velocity_joint_commands.append(0.0)
-            self.effort_joint_commands.append(0.0)
-            # used only in velocity and position control mode
-            self.force_commands.append(max_effort)
-            # get joint name from dictionary, is used for naming the subscriber
-            joint_name = self.joint_index_name_dic[joint_index]
-            # create list of joints for later use in pve_ctrl_cmd(...)
-            self.joint_indices.append(joint_index)
-            # create position control object
-            self.pc_subscribers.append(pveControl(joint_index, joint_name, 'position'))
-            # create position control object
-            self.vc_subscribers.append(pveControl(joint_index, joint_name, 'velocity'))
-            # create position control object
-            self.ec_subscribers.append(pveControl(joint_index, joint_name, 'effort'))
+        self.pc_subscriber = pveControl('position')
+        self.vc_subscriber = pveControl('velocity')
+        self.ec_subscriber = pveControl('effort')
 
     def execute(self):
         """this function gets called from pybullet ros main update loop"""
@@ -102,26 +79,24 @@ class Control:
         position_ctrl_task = False
         velocity_ctrl_task = False
         effort_ctrl_task = False
-        for index, subscriber in enumerate(self.pc_subscribers):
-            if subscriber.get_is_data_available():
-                self.position_joint_commands[index] = subscriber.get_last_cmd()
-                position_ctrl_task = True
-        for index, subscriber in enumerate(self.vc_subscribers):
-            if subscriber.get_is_data_available():
-                self.velocity_joint_commands[index] = subscriber.get_last_cmd()
-                velocity_ctrl_task = True
-        for index, subscriber in enumerate(self.ec_subscribers):
-            if subscriber.get_is_data_available():
-                self.effort_joint_commands[index] = subscriber.get_last_cmd()
-                effort_ctrl_task = True
+        if self.pc_subscriber.get_is_data_available():
+            self.position_joint_commands = self.pc_subscriber.get_last_cmd()
+            position_ctrl_task = True
+        if self.vc_subscriber.get_is_data_available():
+            self.velocity_joint_commands = self.vc_subscriber.get_last_cmd()
+            velocity_ctrl_task = True
+        if self.ec_subscriber.get_is_data_available():
+            self.effort_joint_commands = self.ec_subscriber.get_last_cmd()
+            effort_ctrl_task = True
         # forward commands to pybullet, give priority to position control cmds, then vel, at last effort
         if position_ctrl_task:
             self.pb.setJointMotorControlArray(bodyUniqueId=self.robot, jointIndices=self.joint_indices,
-                                     controlMode=self.pb.POSITION_CONTROL, targetPositions=self.position_joint_commands, forces=self.force_commands)
+                                              controlMode=self.pb.POSITION_CONTROL,
+                                              targetPositions=self.position_joint_commands, forces=self.force_commands)
         elif velocity_ctrl_task:
             self.pb.setJointMotorControlArray(bodyUniqueId=self.robot, jointIndices=self.joint_indices,
-                                     controlMode=self.pb.VELOCITY_CONTROL, targetVelocities=self.velocity_joint_commands, forces=self.force_commands)
+                                              controlMode=self.pb.VELOCITY_CONTROL,
+                                              targetVelocities=self.velocity_joint_commands, forces=self.force_commands)
         elif effort_ctrl_task:
             self.pb.setJointMotorControlArray(bodyUniqueId=self.robot, jointIndices=self.joint_indices,
-                                     controlMode=self.pb.TORQUE_CONTROL, forces=self.effort_joint_commands)
-        
+                                              controlMode=self.pb.TORQUE_CONTROL, forces=self.effort_joint_commands)

--- a/ros/src/pybullet_ros/plugins/control.py
+++ b/ros/src/pybullet_ros/plugins/control.py
@@ -75,21 +75,17 @@ class Control:
         """check if user has commanded a joint and forward the request to pybullet"""
         # flag to indicate there are pending position control tasks
         control_params = {"bodyUniqueId": self.robot, "jointIndices": self.joint_indices}
-        command_available = False
         if self.pc_subscriber.get_is_data_available():
             control_params["controlMode"] = self.pb.POSITION_CONTROL
             control_params["targetPositions"] = self.pc_subscriber.get_last_cmd()
             control_params["forces"] = self.force_commands
-            command_available = True
         if self.vc_subscriber.get_is_data_available():
             control_params["controlMode"] = self.pb.VELOCITY_CONTROL
             control_params["targetVelocities"] = self.vc_subscriber.get_last_cmd()
             control_params["forces"] = self.force_commands
-            command_available = True
         if self.ec_subscriber.get_is_data_available():
             control_params["controlMode"] = self.pb.TORQUE_CONTROL
             control_params["forces"] = self.ec_subscriber.get_last_cmd()
-            command_available = True
 
-        if command_available:
+        if "controlMode" in control_params.keys():
             self.pb.setJointMotorControlArray(**control_params)


### PR DESCRIPTION
The `control` plugin used to generate one subscriber per command type and per joint (therefore 21 topics for the franka). I wanted to just have one subscriber per controller (position, velocity, effort). I think this PR is a good start for you to get familiar with the code, especially the neat solution with plugins that are executed in parallel. Note that I don't think the effort control works yet, haven't even tested it yet with this branch.

Try to run the following:
```
cd docker
bash build-run.sh
roslaunch pybullet_robot franka.launch
# in another terminal
bash build-run.sh
roslaunch pybullet_robot position_cmd_gui.launch # play around a bit and put it into a normal position
# close the position gui, yet in another terminal, check out branch feature/ros-velocity-sim from control_libraries and run the demo in ros_examples
```
The robot should move to pose (0.5 0 0.5, 0 1 0 0).

Happy to discuss what your impressions are after. I have a few ideas for improvement and you can maybe give me some advice on the  `FuncExecManager` class afterwards. There is some stuff going on there that I find a bit weird.

For example, I would like to create a `Robot` class that handles everything related to the robot description and executing joint commands (similar to what I had in the other repo). And a controller manager could be nice too to switch between control types.