### PR TITLE
Add simulation class

### DIFF
--- a/ros/launch/bringup_robot_example.launch
+++ b/ros/launch/bringup_robot_example.launch
@@ -13,7 +13,7 @@
     <arg name="rviz_bringup" default="False"/>
     <arg name="rviz_config" default="$(find pybullet_ros)/ros/config/rviz/pybullet_config.rviz"/>
     <arg name="robot_urdf_path" default="$(find pybullet_ros)/common/test/urdf/r2d2_robot/r2d2.urdf.xacro"/>
-    <arg name="pause_simulation" default="False"/>
+    <arg name="start_paused" default="False"/>
     <arg name="parallel_plugin_execution" default="True"/>
     <arg name="robot_pose_x" default="0.0"/>
     <arg name="robot_pose_y" default="0.0"/>
@@ -40,7 +40,7 @@
         <arg name="rviz_bringup" value="$(arg rviz_bringup)"/>
         <arg name="rviz_config" value="$(arg rviz_config)"/>
         <arg name="robot_urdf_path" value="$(arg robot_urdf_path)"/>
-        <arg name="pause_simulation" value="$(arg pause_simulation)"/>
+        <arg name="start_paused" value="$(arg start_paused)"/>
         <arg name="parallel_plugin_execution" value="$(arg parallel_plugin_execution)"/>
         <arg name="robot_pose_x" value="$(arg robot_pose_x)"/>
         <arg name="robot_pose_y" value="$(arg robot_pose_y)"/>

--- a/ros/launch/pybullet_ros_example.launch
+++ b/ros/launch/pybullet_ros_example.launch
@@ -12,7 +12,7 @@
     <arg name="rviz_bringup" default="False"/>
     <arg name="rviz_config" default="$(find pybullet_ros)/ros/config/rviz/pybullet_config.rviz"/>
     <arg name="robot_urdf_path" default="$(find pybullet_ros)/common/test/urdf/r2d2_robot/r2d2.urdf"/>
-    <arg name="pause_simulation" default="False"/> <!-- if true, will boot with paused physics -->
+    <arg name="start_paused" default="False"/> <!-- if true, will boot with paused physics -->
     <arg name="parallel_plugin_execution" default="True"/>
     <arg name="robot_pose_x" default="0.0"/> <!-- robot spawn pose is set here -->
     <arg name="robot_pose_y" default="0.0"/>
@@ -29,7 +29,7 @@
         <param name="pybullet_gui" value="$(arg pybullet_gui)"/>
         <param name="gui_options" value="$(arg gui_options)"/>
         <param name="robot_urdf_path" value="$(arg robot_urdf_path)"/>
-        <param name="pause_simulation" value="$(arg pause_simulation)"/>
+        <param name="start_paused" value="$(arg start_paused)"/>
         <param name="parallel_plugin_execution" value="$(arg parallel_plugin_execution)"/>
         <param name="robot_pose_x" value="$(arg robot_pose_x)"/>
         <param name="robot_pose_y" value="$(arg robot_pose_y)"/>

--- a/ros/launch/robots/franka.launch
+++ b/ros/launch/robots/franka.launch
@@ -13,7 +13,7 @@
     <arg name="rviz_bringup" default="True"/>
     <arg name="rviz_config" default="$(find pybullet_ros)/ros/config/rviz/franka.rviz"/>
     <arg name="robot_urdf_path" default="$(find franka_panda_description)/robots/panda_arm.urdf.xacro"/>
-    <arg name="pause_simulation" default="False"/>
+    <arg name="start_paused" default="False"/>
     <arg name="parallel_plugin_execution" default="True"/>
     <arg name="robot_pose_x" default="0.0"/>
     <arg name="robot_pose_y" default="0.0"/>
@@ -40,7 +40,7 @@
         <arg name="rviz_bringup" value="$(arg rviz_bringup)"/>
         <arg name="rviz_config" value="$(arg rviz_config)"/>
         <arg name="robot_urdf_path" value="$(arg robot_urdf_path)"/>
-        <arg name="pause_simulation" value="$(arg pause_simulation)"/>
+        <arg name="start_paused" value="$(arg start_paused)"/>
         <arg name="parallel_plugin_execution" value="$(arg parallel_plugin_execution)"/>
         <arg name="robot_pose_x" value="$(arg robot_pose_x)"/>
         <arg name="robot_pose_y" value="$(arg robot_pose_y)"/>

--- a/ros/src/pybullet_ros/pybullet_ros.py
+++ b/ros/src/pybullet_ros/pybullet_ros.py
@@ -3,10 +3,10 @@
 import importlib
 import os
 
-import pybullet_data
 import rospy
 from pybullet_ros.function_exec_manager import FuncExecManager
-from std_srvs.srv import Empty
+
+from .pybullet_sim import PyBulletSim
 
 
 class pyBulletRosWrapper(object):
@@ -18,19 +18,9 @@ class pyBulletRosWrapper(object):
         # get from param server the frequency at which to run the simulation
         self.loop_rate = rospy.get_param('~loop_rate', 80.0)
         # query from param server if gui is needed
-        is_gui_needed = rospy.get_param('~pybullet_gui', True)
-        # get from param server if user wants to pause simulation at startup
-        self.pause_simulation = rospy.get_param('~pause_simulation', False)
-        print('\033[34m')
-        # print pybullet stuff in blue
-        physicsClient = self.start_gui(gui=is_gui_needed)  # we dont need to store the physics client for now...
-        # setup service to restart simulation
-        rospy.Service('~reset_simulation', Empty, self.handle_reset_simulation)
-        # setup services for pausing/unpausing simulation
-        rospy.Service('~pause_physics', Empty, self.handle_pause_physics)
-        rospy.Service('~unpause_physics', Empty, self.handle_unpause_physics)
-        # get pybullet path in your system and store it internally for future use, e.g. to set floor
-        self.pb.setAdditionalSearchPath(pybullet_data.getDataPath())
+        start_pybullet_gui = rospy.get_param("~pybullet_gui", True)
+        start_paused = rospy.get_param("~start_paused", False)
+        self.simulation = PyBulletSim(gui=start_pybullet_gui, start_paused=start_paused)
         # create object of environment class for later use
         env_plugin = rospy.get_param('~environment', 'environment')  # default : plugins/environment.py
         plugin_import_prefix = rospy.get_param('~plugin_import_prefix', 'pybullet_ros.plugins')
@@ -96,12 +86,6 @@ class pyBulletRosWrapper(object):
             elif info[2] == self.pb.JOINT_PRISMATIC:
                 prismatic_joint_index_name_dic[joint_index] = info[1].decode('utf-8')  # info[1] refers to joint name
         return rev_joint_index_name_dic, prismatic_joint_index_name_dic, fixed_joint_index_name_dic, link_names_to_ids_dic
-
-    def handle_reset_simulation(self, req):
-        """Callback to handle the service offered by this node to reset the simulation"""
-        rospy.loginfo('reseting simulation now')
-        self.pb.resetSimulation()
-        return Empty()
 
     def start_gui(self, gui=True):
         """start physics engine (client) with or without gui"""
@@ -216,35 +200,32 @@ class pyBulletRosWrapper(object):
         """
         rate = rospy.Rate(self.loop_rate)
         while not rospy.is_shutdown():
-            if not self.pause_simulation:
+            if not self.simulation.is_paused():
                 # run x plugins
                 for task in self.plugins:
                     task.execute()
                 # perform all the actions in a single forward dynamics simulation step such
                 # as collision detection, constraint solving and integration
-                self.pb.stepSimulation()
+                self.simulation.step()
             rate.sleep()
-        rospy.logwarn('killing node now...')
-        # if node is killed, disconnect
-        if self.connected_to_physics_server:
-            self.pb.disconnect()
+        rospy.logwarn("[PyBulletROSWrapper] Killing all programs now.")
+        if self.simulation.is_alive():
+            del self.simulation
 
     def start_pybullet_ros_wrapper_parallel(self):
         """
         Execute plugins in parallel, however watch their execution time and warn if exceeds the deadline (loop rate)
         """
         # create object of our parallel execution manager
-        exec_manager_obj = FuncExecManager(self.plugins, rospy.is_shutdown, self.pb.stepSimulation,
-                                           self.pause_simulation_function,
+        exec_manager_obj = FuncExecManager(self.plugins, rospy.is_shutdown, self.simulation.step,
+                                           self.simulation.is_paused,
                                            log_info=rospy.loginfo, log_warn=rospy.logwarn, log_debug=rospy.logdebug,
                                            function_name='plugin')
         # start parallel execution of all "execute" class methods in a synchronous way
         exec_manager_obj.start_synchronous_execution(loop_rate=self.loop_rate)
-        # ctrl + c was pressed, exit
-        rospy.logwarn('killing node now...')
-        # if node is killed, disconnect
-        if self.connected_to_physics_server:
-            self.pb.disconnect()
+        rospy.logwarn("[PyBulletROSWrapper] Killing all programs now.")
+        if self.simulation.is_alive():
+            del self.simulation
 
     def start_pybullet_ros_wrapper(self):
         if rospy.get_param('~parallel_plugin_execution', True):

--- a/ros/src/pybullet_ros/pybullet_ros.py
+++ b/ros/src/pybullet_ros/pybullet_ros.py
@@ -87,22 +87,6 @@ class pyBulletRosWrapper(object):
                 prismatic_joint_index_name_dic[joint_index] = info[1].decode('utf-8')  # info[1] refers to joint name
         return rev_joint_index_name_dic, prismatic_joint_index_name_dic, fixed_joint_index_name_dic, link_names_to_ids_dic
 
-    def start_gui(self, gui=True):
-        """start physics engine (client) with or without gui"""
-        if gui:
-            # start simulation with gui
-            rospy.loginfo('Running pybullet with gui')
-            rospy.loginfo('-------------------------')
-            gui_options = rospy.get_param('~gui_options',
-                                          '')  # e.g. to maximize screen: options="--width=2560 --height=1440"
-            return self.pb.connect(self.pb.GUI, options=gui_options)
-        else:
-            # start simulation without gui (non-graphical version)
-            rospy.loginfo('Running pybullet without gui')
-            # hide console output from pybullet
-            rospy.loginfo('-------------------------')
-            return self.pb.connect(self.pb.DIRECT)
-
     def init_pybullet_robot(self):
         """load robot URDF model, set gravity, ground plane and environment"""
         # get from param server the path to the URDF robot model to load at startup
@@ -165,34 +149,6 @@ class pyBulletRosWrapper(object):
             lower_lim = self.pb.getJointInfo(robot, joint_id)[8]
             upper_lim = self.pb.getJointInfo(robot, joint_id)[9]
             self.pb.resetJointState(robot, joint_id, (upper_lim + lower_lim) / 2)
-
-    def handle_reset_simulation(self, req):
-        """Callback to handle the service offered by this node to reset the simulation"""
-        rospy.loginfo('reseting simulation now')
-        # pause simulation to prevent reading joint values with an empty world
-        self.pause_simulation = True
-        # remove all objects from the world and reset the world to initial conditions
-        self.pb.resetSimulation()
-        # load URDF model again, set gravity and floor
-        self.init_pybullet_robot()
-        # resume simulation control cycle now that a new robot is in place
-        self.pause_simulation = False
-        return []
-
-    def handle_pause_physics(self, req):
-        """pause simulation, raise flag to prevent pybullet to execute self.pb.stepSimulation()"""
-        rospy.loginfo('pausing simulation')
-        self.pause_simulation = False
-        return []
-
-    def handle_unpause_physics(self, req):
-        """unpause simulation, lower flag to allow pybullet to execute self.pb.stepSimulation()"""
-        rospy.loginfo('unpausing simulation')
-        self.pause_simulation = True
-        return []
-
-    def pause_simulation_function(self):
-        return self.pause_simulation
 
     def start_pybullet_ros_wrapper_sequential(self):
         """

--- a/ros/src/pybullet_ros/pybullet_sim.py
+++ b/ros/src/pybullet_ros/pybullet_sim.py
@@ -1,0 +1,142 @@
+import os
+
+import pybullet as pb
+import pybullet_data as pb_data
+import rospy
+from std_srvs.srv import Trigger, TriggerResponse
+
+
+class PyBulletSim(object):
+    """
+    The Simulation class creates the PyBullet physics server and optionally a GUI.
+
+    Available methods (for usage, see documentation at function definition):
+        - is_alive
+        - step
+        - add_pybullet_path
+        - add_search_path
+    """
+
+    def __init__(self, gui=True, gui_options="", start_paused=False):
+        """
+        Constructor of the Simulation class. This class creates the PyBullet server / GUI and steps the simulation.
+
+        :param gui: Start PyBullet with a GUI
+        :param gui_options: GUI options, e.g. "--width=2560 --height=1440"
+        :param start_paused: Start simulation paused
+
+        :type gui: bool
+        :type gui_options: str
+        :type start_paused: bool
+        """
+        assert isinstance(gui, bool), "[PyBulletSim::init] Parameter 'gui' has an incorrect type."
+        assert isinstance(gui_options, str), "[PyBulletSim::init] Parameter 'gui_options' has an incorrect type."
+        assert isinstance(start_paused, bool), "[PyBulletSim::init] Parameter 'start_paused' has an incorrect type."
+
+        if gui:
+            rospy.loginfo("[PyBulletSim::init] Running PyBullet with GUI")
+            rospy.loginfo("-------------------------")
+            print("\033[34m")  # print PyBullet stuff in blue
+            gui_options = rospy.get_param("~gui_options",
+                                          "")  # e.g. to maximize screen: options="--width=2560 --height=1440"
+            self._uid = pb.connect(pb.GUI, options=gui_options)
+        else:
+            rospy.loginfo("[PyBulletSim::init] Running PyBullet without GUI")
+            rospy.loginfo("-------------------------")
+            print("\033[34m")  # print PyBullet stuff in blue
+            self._uid = pb.connect(pb.DIRECT)
+
+        self.simulation_paused = start_paused
+
+        self.add_pybullet_path()
+
+        # setup services to pause/unpause and restart simulation
+        rospy.Service("~reset_simulation", Trigger, self.reset_simulation)
+        rospy.Service("~pause_simulation", Trigger, self.pause_simulation)
+        rospy.Service("~unpause_simulation", Trigger, self.unpause_simulation)
+
+    def __del__(self):
+        """
+        Disconnect the physics server
+        """
+        pb.disconnect(self._uid)
+
+    def is_alive(self):
+        """
+        Check if the physics server is still connected
+
+        :rtype: bool
+        """
+        return pb.isConnected(self._uid)
+
+    def is_paused(self):
+        """
+        Check if the simulation if paused.
+
+        :rtype: bool
+        """
+        return self.simulation_paused
+
+    def step(self):
+        """
+        Step the simulation.
+        """
+        pb.stepSimulation(self._uid)
+
+    def reset_simulation(self, req):
+        """
+        Reset the simulation.
+        """
+        self.pause_simulation(Trigger)
+        rospy.loginfo("[PyBulletSim::reset_simulation] Resetting simulation.")
+        # FIXME calling this will cause the simulation to crash because the joint state plugin cannot get the state
+        # pb.resetSimulation(physicsClientId=self._uid)
+        self.unpause_simulation(Trigger)
+        res = TriggerResponse(True, "Simulation reset")
+        return res
+
+    def pause_simulation(self, req):
+        """
+        Pause the simulation, i.e. disable the stepSimulation() call.
+        """
+        rospy.loginfo("[PyBulletSim::pause_simulation] Pausing simulation.")
+        self.simulation_paused = True
+        res = TriggerResponse(True, "Simulation paused")
+        return res
+
+    def unpause_simulation(self, req):
+        """
+        Continue the simulation, i.e. enable the stepSimulation() call.
+        """
+        rospy.loginfo("[PyBulletSim::unpause_simulation] Unpausing simulation.")
+        self.simulation_paused = False
+        res = TriggerResponse(True, "Simulation unpaused")
+        return res
+
+    @staticmethod
+    def add_pybullet_path():
+        """
+        Adds PyBullets in-built models path to the PyBullet path for easily retrieving the models.
+        """
+        pb.setAdditionalSearchPath(pb_data.getDataPath())
+
+    @staticmethod
+    def add_search_path(path):
+        """
+        Add the specified directory (absolute path) to PyBullets search path for easily adding models from the path.
+
+        :param path: The absolute path to the directory
+        :type path: str
+
+        :return: isdir: Boolean if action was successful
+        :rtype: isdir: bool
+        """
+        assert isinstance(path, str), "[PyBulletSim::add_search_path] Parameter 'path' has an incorrect type."
+        if os.path.isdir(path):
+            pb.setAdditionalSearchPath(path)
+            rospy.loginfo("[PyBulletSim::add_search_path] Added {} to PyBullet path.".format(path))
+            return True
+        else:
+            rospy.logerr(
+                "[PyBulletSim::add_search_path] Error adding to PyBullet path! {} not a directory.".format(path))
+            return False


### PR DESCRIPTION
I didn't like how some services were created in the main wrapper class and decided therefore to move everything related to stepping/pausing the simulation and the gui to a seperate class. I think this improves the readability of the wrapper class and its nice to have this `self.simulation` variable.