### PR TITLE
Set initial joint configurations to mean of joint limits

### DIFF
--- a/ros/src/pybullet_ros/pybullet_ros.py
+++ b/ros/src/pybullet_ros/pybullet_ros.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 
-import os
 import importlib
-import rospy
-import pybullet_data
+import os
 
-from std_srvs.srv import Empty
+import pybullet_data
+import rospy
 from pybullet_ros.function_exec_manager import FuncExecManager
+from std_srvs.srv import Empty
+
 
 class pyBulletRosWrapper(object):
     """ROS wrapper class for pybullet simulator"""
+
     def __init__(self):
         # import pybullet
         self.pb = importlib.import_module('pybullet')
@@ -21,7 +23,7 @@ class pyBulletRosWrapper(object):
         self.pause_simulation = rospy.get_param('~pause_simulation', False)
         print('\033[34m')
         # print pybullet stuff in blue
-        physicsClient = self.start_gui(gui=is_gui_needed) # we dont need to store the physics client for now...
+        physicsClient = self.start_gui(gui=is_gui_needed)  # we dont need to store the physics client for now...
         # setup service to restart simulation
         rospy.Service('~reset_simulation', Empty, self.handle_reset_simulation)
         # setup services for pausing/unpausing simulation
@@ -30,19 +32,22 @@ class pyBulletRosWrapper(object):
         # get pybullet path in your system and store it internally for future use, e.g. to set floor
         self.pb.setAdditionalSearchPath(pybullet_data.getDataPath())
         # create object of environment class for later use
-        env_plugin = rospy.get_param('~environment', 'environment') # default : plugins/environment.py
+        env_plugin = rospy.get_param('~environment', 'environment')  # default : plugins/environment.py
         plugin_import_prefix = rospy.get_param('~plugin_import_prefix', 'pybullet_ros.plugins')
-        self.environment = getattr(importlib.import_module(f'{plugin_import_prefix}.{env_plugin}'), 'Environment')(self.pb)
+        self.environment = getattr(importlib.import_module(f'{plugin_import_prefix}.{env_plugin}'), 'Environment')(
+            self.pb)
         # load robot URDF model, set gravity, and ground plane
         self.robot = self.init_pybullet_robot()
         self.connected_to_physics_server = None
         if not self.robot:
             self.connected_to_physics_server = False
-            return # Error while loading urdf file
+            return  # Error while loading urdf file
         else:
             self.connected_to_physics_server = True
         # get all revolute joint names and pybullet index
         rev_joint_index_name_dic, prismatic_joint_index_name_dic, fixed_joint_index_name_dic, link_names_to_ids_dic = self.get_properties()
+        self.set_initial_joint_configuration(self.robot, rev_joint_index_name_dic)
+        self.set_initial_joint_configuration(self.robot, prismatic_joint_index_name_dic)
         # import plugins dynamically
         self.plugins = []
         plugins = rospy.get_param('~plugins', [])
@@ -58,11 +63,11 @@ class pyBulletRosWrapper(object):
             rospy.loginfo('loading plugin: {} class from {}'.format(class_, module_))
             # create object of the imported file class
             obj = getattr(importlib.import_module(module_), class_)(self.pb, self.robot,
-                          rev_joints=rev_joint_index_name_dic,
-                          prism_joints=prismatic_joint_index_name_dic,
-                          fixed_joints=fixed_joint_index_name_dic,
-                          link_ids=link_names_to_ids_dic,
-                          **params_)
+                                                                    rev_joints=rev_joint_index_name_dic,
+                                                                    prism_joints=prismatic_joint_index_name_dic,
+                                                                    fixed_joints=fixed_joint_index_name_dic,
+                                                                    link_ids=link_names_to_ids_dic,
+                                                                    **params_)
             # store objects in member variable for future use
             self.plugins.append(obj)
         rospy.loginfo('pybullet ROS wrapper initialized')
@@ -84,12 +89,12 @@ class pyBulletRosWrapper(object):
             # ensure we are dealing with a revolute joint
             if info[2] == self.pb.JOINT_REVOLUTE:
                 # insert key, value in dictionary (joint index, joint name)
-                rev_joint_index_name_dic[joint_index] = info[1].decode('utf-8') # info[1] refers to joint name
+                rev_joint_index_name_dic[joint_index] = info[1].decode('utf-8')  # info[1] refers to joint name
             elif info[2] == self.pb.JOINT_FIXED:
                 # insert key, value in dictionary (joint index, joint name)
-                fixed_joint_index_name_dic[joint_index] = info[1].decode('utf-8') # info[1] refers to joint name
+                fixed_joint_index_name_dic[joint_index] = info[1].decode('utf-8')  # info[1] refers to joint name
             elif info[2] == self.pb.JOINT_PRISMATIC:
-                prismatic_joint_index_name_dic[joint_index] = info[1].decode('utf-8') # info[1] refers to joint name
+                prismatic_joint_index_name_dic[joint_index] = info[1].decode('utf-8')  # info[1] refers to joint name
         return rev_joint_index_name_dic, prismatic_joint_index_name_dic, fixed_joint_index_name_dic, link_names_to_ids_dic
 
     def handle_reset_simulation(self, req):
@@ -100,11 +105,12 @@ class pyBulletRosWrapper(object):
 
     def start_gui(self, gui=True):
         """start physics engine (client) with or without gui"""
-        if(gui):
+        if (gui):
             # start simulation with gui
             rospy.loginfo('Running pybullet with gui')
             rospy.loginfo('-------------------------')
-            gui_options = rospy.get_param('~gui_options', '') # e.g. to maximize screen: options="--width=2560 --height=1440"
+            gui_options = rospy.get_param('~gui_options',
+                                          '')  # e.g. to maximize screen: options="--width=2560 --height=1440"
             return self.pb.connect(self.pb.GUI, options=gui_options)
         else:
             # start simulation without gui (non-graphical version)
@@ -131,12 +137,15 @@ class pyBulletRosWrapper(object):
                 rospy.logerr('required robot_description param not set')
                 return None
             # remove xacro from name
-            urdf_path_without_xacro = urdf_path[0:urdf_path.find('.xacro')]+urdf_path[urdf_path.find('.xacro')+len('.xacro'):]
-            rospy.loginfo('generating urdf model from xacro from robot_description param server under: {0}'.format(urdf_path_without_xacro))
+            urdf_path_without_xacro = urdf_path[0:urdf_path.find('.xacro')] + urdf_path[
+                                                                              urdf_path.find('.xacro') + len('.xacro'):]
+            rospy.loginfo('generating urdf model from xacro from robot_description param server under: {0}'.format(
+                urdf_path_without_xacro))
             try:
-                urdf_file = open(urdf_path_without_xacro,'w')
+                urdf_file = open(urdf_path_without_xacro, 'w')
             except:
-                rospy.logerr('Failed to create urdf file from xacro, cannot write into destination: {0}'.format(urdf_path_without_xacro))
+                rospy.logerr('Failed to create urdf file from xacro, cannot write into destination: {0}'.format(
+                    urdf_path_without_xacro))
                 return None
             urdf_file.write(robot_description)
             urdf_file.close()
@@ -159,12 +168,20 @@ class pyBulletRosWrapper(object):
         rospy.loginfo('loading environment')
         self.environment.load_environment()
         # set no realtime simulation, NOTE: no need to stepSimulation if setRealTimeSimulation is set to 1
-        self.pb.setRealTimeSimulation(0) # NOTE: does not currently work with effort controller, thats why is left as 0
+        self.pb.setRealTimeSimulation(0)  # NOTE: does not currently work with effort controller, thats why is left as 0
         rospy.loginfo('loading urdf model: ' + urdf_path)
         # NOTE: self collision enabled by default
         return self.pb.loadURDF(urdf_path, basePosition=[robot_pose_x, robot_pose_y, robot_pose_z],
-                                           baseOrientation=robot_spawn_orientation,
-                                           useFixedBase=fixed_base, flags=urdf_flags)
+                                baseOrientation=robot_spawn_orientation,
+                                useFixedBase=fixed_base, flags=urdf_flags)
+
+    def set_initial_joint_configuration(self, robot, joint_dict):
+        """Function to set initial joint configuration to the mean of the joint position limits."""
+        for joint_id, joint_name in joint_dict.items():
+            lower_lim = self.pb.getJointInfo(robot, joint_id)[8]
+            upper_lim = self.pb.getJointInfo(robot, joint_id)[9]
+            print(-(upper_lim - lower_lim) / 2)
+            self.pb.resetJointState(robot, joint_id, (upper_lim + lower_lim) / 2)
 
     def handle_reset_simulation(self, req):
         """Callback to handle the service offered by this node to reset the simulation"""
@@ -218,8 +235,10 @@ class pyBulletRosWrapper(object):
         Execute plugins in parallel, however watch their execution time and warn if exceeds the deadline (loop rate)
         """
         # create object of our parallel execution manager
-        exec_manager_obj = FuncExecManager(self.plugins, rospy.is_shutdown, self.pb.stepSimulation, self.pause_simulation_function,
-                                    log_info=rospy.loginfo, log_warn=rospy.logwarn, log_debug=rospy.logdebug, function_name='plugin')
+        exec_manager_obj = FuncExecManager(self.plugins, rospy.is_shutdown, self.pb.stepSimulation,
+                                           self.pause_simulation_function,
+                                           log_info=rospy.loginfo, log_warn=rospy.logwarn, log_debug=rospy.logdebug,
+                                           function_name='plugin')
         # start parallel execution of all "execute" class methods in a synchronous way
         exec_manager_obj.start_synchronous_execution(loop_rate=self.loop_rate)
         # ctrl + c was pressed, exit
@@ -234,8 +253,9 @@ class pyBulletRosWrapper(object):
         else:
             self.start_pybullet_ros_wrapper_sequential()
 
+
 def main():
     """function called by pybullet_ros_node script"""
-    rospy.init_node('pybullet_ros', anonymous=False) # node name gets overrided if launched by a launch file
+    rospy.init_node('pybullet_ros', anonymous=False)  # node name gets overrided if launched by a launch file
     pybullet_ros_interface = pyBulletRosWrapper()
     pybullet_ros_interface.start_pybullet_ros_wrapper()

--- a/ros/src/pybullet_ros/pybullet_ros.py
+++ b/ros/src/pybullet_ros/pybullet_ros.py
@@ -105,7 +105,7 @@ class pyBulletRosWrapper(object):
 
     def start_gui(self, gui=True):
         """start physics engine (client) with or without gui"""
-        if (gui):
+        if gui:
             # start simulation with gui
             rospy.loginfo('Running pybullet with gui')
             rospy.loginfo('-------------------------')
@@ -180,7 +180,6 @@ class pyBulletRosWrapper(object):
         for joint_id, joint_name in joint_dict.items():
             lower_lim = self.pb.getJointInfo(robot, joint_id)[8]
             upper_lim = self.pb.getJointInfo(robot, joint_id)[9]
-            print(-(upper_lim - lower_lim) / 2)
             self.pb.resetJointState(robot, joint_id, (upper_lim + lower_lim) / 2)
 
     def handle_reset_simulation(self, req):


### PR DESCRIPTION
I added a function that sets the initial joint configuration to the mean of the joint position limits after the robot is loaded. The rest of the diff is just auto-formatting.

I'd like to bring this in such that the ros demo in control_libraries is easier to explain and use.

As we discussed, it would be nice to create a service for this, such that the user can just restart his control node without restarting the main simulation.