### PR TITLE
Fixes for multiple robots

### DIFF
--- a/ros/src/pybullet_ros/pybullet_robot.py
+++ b/ros/src/pybullet_ros/pybullet_robot.py
@@ -39,9 +39,7 @@ class PyBulletRobot(PyBulletRobotDescription):
                 "[PyBulletRobot::init] Invalid name '{}' for a PyBulletRobot. Allowed characters are [a-zA-Z0-9_]. " +
                 "Exiting now.".format(name))
             return
-        self._namespace = "/" + name + "/"
-        PyBulletRobotDescription.__init__(self, self._namespace, self._uid)
-        self._initialized = self.is_initialized
+        PyBulletRobotDescription.__init__(self, name, self._uid)
         
     def get_joint_state_msg(self):
         msg = JointState()

--- a/ros/src/pybullet_ros/pybullet_ros.py
+++ b/ros/src/pybullet_ros/pybullet_ros.py
@@ -40,10 +40,13 @@ class PyBulletRosWrapper(object):
             self._robots[robot_name] = robot
             # import plugins dynamically
             for plugin in plugins:
-                module_ = plugin.pop("module")
-                class_ = plugin.pop("class")
-                params_ = plugin.copy()
-                rospy.loginfo("[PyBulletRosWrapper::init] Loading plugin: {} class from {}".format(class_, module_))
+                plugin_ = plugin.copy()
+                module_ = plugin_.pop("module")
+                class_ = plugin_.pop("class")
+                params_ = plugin_.copy()
+                rospy.loginfo(
+                    "[PyBulletRosWrapper::init] Loading plugin: {} class from {} for robot {}".format(class_, module_,
+                                                                                                      robot_name))
                 # create object of the imported file class
                 obj = getattr(importlib.import_module(module_), class_)(self._pb, robot, **params_)
                 # store objects in member variable for future use


### PR DESCRIPTION
To have several robots that possibly have the same urdf path, you need to make the urdf_path where the robot_description is saved unique to the robot, otherwise it's overwritten. Thus the changes in pybullet_robot and pybullet_robot_description.

Also, the `plugin.pop()` doesn't work because it will change the original variable and only work for the first robot. Therefore, you need to copy it before `pop`.